### PR TITLE
feat:  hover mechanism per PokeCard 

### DIFF
--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -62,10 +62,10 @@ const StyledCard = styled(Card)`
 const StyledImg = styled.img`
   min-width: 20%;
   max-width: 40%;
-  max-height: 30%;
   border: 0.5px solid ${colors.primaryWhite};
   border-radius: 50%;
   background-color: ${colors.skin};
+  object-fit: contain;
 `;
 
 const StyledText = styled.p`

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -2,6 +2,7 @@ import "antd/dist/antd.css";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Card } from "antd";
+
 import { colors } from "utils/themes/colors";
 import { POKEMON_TYPES, SAMPLE_POKEMON_URL } from "utils/constants";
 

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -2,13 +2,15 @@ import "antd/dist/antd.css";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Card } from "antd";
+import { capitalize, isEmpty } from "lodash";
 
 import { colors } from "utils/themes/colors";
 import { POKEMON_TYPES, SAMPLE_POKEMON_URL } from "utils/constants";
+import { PokeStat } from "components/PokeStat";
 
 const HoverCard = styled.div`
   position: absolute;
-  background-color: brown;
+  background-color: ${colors.secondaryGray};
   position: absolute;
   bottom: 0;
   left: 0;
@@ -21,6 +23,10 @@ const HoverCard = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  overflow: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Container = styled.div`
@@ -79,7 +85,12 @@ const StyledId = styled.p`
   background-color: ${colors.primaryGray};
 `;
 
-export const PokeCard = ({ name, type, id, backgroundColor, src }) => {
+const StatContainer = styled.div`
+  margin-top: 1rem;
+  width: 100%;
+`;
+
+export const PokeCard = ({ name, type, id, backgroundColor, src, stats }) => {
   return (
     <Container>
       <StyledCard bgcolor={backgroundColor}>
@@ -89,11 +100,19 @@ export const PokeCard = ({ name, type, id, backgroundColor, src }) => {
         <StyledText>{type}</StyledText>
       </StyledCard>
       <HoverCard>
-        <StyledText>{type}</StyledText>
-        <StyledText>{type}</StyledText>
-        <StyledText>{type}</StyledText>
-        <StyledText>{type}</StyledText>
-        <StyledText>{type}</StyledText>
+        {!isEmpty(stats) ? (
+          stats.map((data, index) => {
+            const statName = capitalize(data.stat.name);
+            const level = data.base_stat;
+            return (
+              <StatContainer>
+                <PokeStat key={index} level={level} statName={statName} />
+              </StatContainer>
+            );
+          })
+        ) : (
+          <StyledText>No Stats found...</StyledText>
+        )}
       </HoverCard>
     </Container>
   );

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -10,6 +10,7 @@ const StyledCard = styled(Card)`
   && {
     border-radius: 1rem;
     background-color: ${(props) => props.bgcolor};
+    box-shadow: 0.31rem 0.31rem 0.5rem ${colors.boxShadow};
     &.ant-card .ant-card-body {
       display: flex;
       flex-direction: column;

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -102,11 +102,17 @@ export const PokeCard = ({ name, type, id, backgroundColor, src, stats }) => {
       <HoverCard>
         {!isEmpty(stats) ? (
           stats.map((data, index) => {
+            let level;
             const statName = capitalize(data.stat.name);
-            const level = data.base_stat;
+            if (data.base_stat > 100) {
+              level = 100;
+            } else {
+              level = data.base_stat;
+            }
+
             return (
-              <StatContainer>
-                <PokeStat key={index} level={level} statName={statName} />
+              <StatContainer key={index}>
+                <PokeStat level={level} statName={statName} />
               </StatContainer>
             );
           })

--- a/src/components/Card/index.jsx
+++ b/src/components/Card/index.jsx
@@ -6,21 +6,52 @@ import { Card } from "antd";
 import { colors } from "utils/themes/colors";
 import { POKEMON_TYPES, SAMPLE_POKEMON_URL } from "utils/constants";
 
+const HoverCard = styled.div`
+  position: absolute;
+  background-color: brown;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem;
+  transition: 0.4s ease-in-out;
+  transform: translateY(100%);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  overflow: hidden;
+  position: relative;
+  border-radius: 1rem;
+  transition: box-shadow 0.2s ease-in-out;
+  box-shadow: 0.31rem 0.31rem 0.5rem ${colors.boxShadow};
+  &:hover {
+    box-shadow: 0.5rem 0.5rem 0.6rem ${colors.primaryGray};
+  }
+  &:hover ${HoverCard} {
+    transform: translateY(0%);
+  }
+`;
+
 const StyledCard = styled(Card)`
   && {
-    border-radius: 1rem;
-    background-color: ${(props) => props.bgcolor};
-    box-shadow: 0.31rem 0.31rem 0.5rem ${colors.boxShadow};
     &.ant-card .ant-card-body {
+      background-color: ${(props) => props.bgcolor};
       display: flex;
       flex-direction: column;
       align-items: center;
       padding: 2rem;
-      width: 100% !important;
+      width: 100%;
     }
   }
 `;
-// TODO: add box shadow
 
 const StyledImg = styled.img`
   min-width: 20%;
@@ -50,12 +81,21 @@ const StyledId = styled.p`
 
 export const PokeCard = ({ name, type, id, backgroundColor, src }) => {
   return (
-    <StyledCard bgcolor={backgroundColor}>
-      <StyledImg src={src} />
-      <StyledId>#{id}</StyledId>
-      <StyledText>{name}</StyledText>
-      <StyledText>{type}</StyledText>
-    </StyledCard>
+    <Container>
+      <StyledCard bgcolor={backgroundColor}>
+        <StyledImg src={src} />
+        <StyledId>#{id}</StyledId>
+        <StyledText>{name}</StyledText>
+        <StyledText>{type}</StyledText>
+      </StyledCard>
+      <HoverCard>
+        <StyledText>{type}</StyledText>
+        <StyledText>{type}</StyledText>
+        <StyledText>{type}</StyledText>
+        <StyledText>{type}</StyledText>
+        <StyledText>{type}</StyledText>
+      </HoverCard>
+    </Container>
   );
 };
 

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -17,7 +17,7 @@ const StyledHeader = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  box-shadow: 0.5rem 0.5rem 0.6rem ${colors.primaryGray};
+  box-shadow: -1.5rem 0.5rem 2.6rem ${colors.primaryGray};
 `;
 
 const StyledLogo = styled.img`

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -17,6 +17,7 @@ const StyledHeader = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  box-shadow: 0.5rem 0.5rem 0.6rem ${colors.primaryGray};
 `;
 
 const StyledLogo = styled.img`

--- a/src/components/PokeStat/index.jsx
+++ b/src/components/PokeStat/index.jsx
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import { colors } from "utils/themes/colors";
+import { Slider } from "components/Slider";
+import { SLIDER_RANGE_ARRAY } from "utils/constants";
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: space-evenly;
+`;
+
+const StyledText = styled.span`
+  font-size: 1rem;
+  font-weight: 500;
+  color: ${colors.primaryWhite};
+`;
+
+const SliderContainer = styled.div`
+  margin: 0 1rem;
+  width: inherit;
+`;
+
+export const PokeStat = ({ statName, level }) => {
+  return (
+    <Container>
+      <StyledText>{statName}</StyledText>
+      <SliderContainer>
+        <Slider width={level} />
+      </SliderContainer>
+      <StyledText>{level}</StyledText>
+    </Container>
+  );
+};
+
+PokeStat.propTypes = {
+  statName: PropTypes.string.isRequired,
+  level: PropTypes.oneOf(SLIDER_RANGE_ARRAY.map((_, i) => i + 1)).isRequired,
+};
+
+PokeStat.defaultProps = {
+  level: 80,
+};

--- a/src/components/PokeStat/stories/PokeStat.stories.js
+++ b/src/components/PokeStat/stories/PokeStat.stories.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { PokeStat } from "../index";
+
+export default {
+  title: "Example/Stat",
+  component: PokeStat,
+};
+
+const Template = (args) => <PokeStat {...args} />;
+
+export const Level50 = Template.bind({});
+
+Level50.args = {
+  statName: "Attack",
+  level: 80,
+};

--- a/src/components/Slider/index.jsx
+++ b/src/components/Slider/index.jsx
@@ -2,12 +2,14 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 import { colors } from "utils/themes/colors";
+import { SLIDER_RANGE_ARRAY } from "utils/constants";
 
 const Container = styled.div`
   width: 100%;
   background-color: ${colors.primaryRed};
   color: ${colors.primaryRed};
   position: relative;
+  max-height: 1rem;
 `;
 
 const StyledSpan = styled.span`
@@ -16,23 +18,23 @@ const StyledSpan = styled.span`
   left: 0;
   min-height: 100% !important;
   background-color: ${colors.secondaryRed};
-  color: ${colors.secondaryRed};
-  width: ${(props) => props.width};
+  color: ${colors.primaryRed};
+  width: ${(props) => props.width}%;
 `;
 
 export const Slider = ({ width }) => {
   return (
     <Container>
       Stats Level
-      <StyledSpan width={width}>{width}</StyledSpan>
+      <StyledSpan width={width}></StyledSpan>
     </Container>
   );
 };
 
 Slider.propTypes = {
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  width: PropTypes.oneOf(SLIDER_RANGE_ARRAY.map((_, i) => i + 1)).isRequired,
 };
 
 Slider.defaultProps = {
-  width: "50%",
+  width: 50,
 };

--- a/src/containers/Dashboard/index.jsx
+++ b/src/containers/Dashboard/index.jsx
@@ -84,12 +84,11 @@ export const Dashboard = () => {
         >
           <Grid gutter={24}>
             {individualData.map((pokeData, index) => {
-              const { sprites, species, types } = pokeData;
+              const { stats, sprites, species, types } = pokeData;
               const pokemonType = types[0].type.name;
               const pokemonName = capitalize(species.name);
               const imageSource = sprites.front_default;
               const bgColor = capitalize(getPokeCardColorByType(pokemonType));
-
               return (
                 <StyledCol key={index} span={6}>
                   <PokeCard
@@ -98,6 +97,7 @@ export const Dashboard = () => {
                     name={pokemonName}
                     type={capitalize(pokemonType)}
                     backgroundColor={bgColor}
+                    stats={stats}
                   />
                 </StyledCol>
               );

--- a/src/containers/Dashboard/index.jsx
+++ b/src/containers/Dashboard/index.jsx
@@ -9,16 +9,27 @@ import { getAllPokemons, fetchPokemonsByName } from "services/pokeApi";
 
 import { getPokeCardColorByType } from "./dashboardUtil";
 
+const Container = styled.div`
+  padding: 4rem;
+  background-color: red;
+  background-image: linear-gradient(to right #c9fdbf, red, #fdafbd);
+  background-color: red;
+  background-image: linear-gradient(
+    to right,
+    #cafebf,
+    #d7e9be,
+    #e3d7be,
+    #f1c4bd,
+    #fdb1bd
+  );
+`;
+
 const Grid = styled(Row)`
   && {
     &.ant-row {
       margin: 3rem auto;
     }
   }
-`;
-
-const Container = styled.div`
-  padding: 4rem;
 `;
 
 const StyledCol = styled(Col)`

--- a/src/containers/Dashboard/index.jsx
+++ b/src/containers/Dashboard/index.jsx
@@ -52,8 +52,8 @@ export const Dashboard = () => {
   const [pokeDataSet, setPokeDataSet] = useState([]);
 
   const fetchPokemons = useCallback(
-    async (limit, offset) => {
-      const apiResponse = await getAllPokemons(limit, offset);
+    async (limt = limit, off = offset) => {
+      const apiResponse = await getAllPokemons(limt, off);
       if (!isEmpty(apiResponse)) {
         const pokemonArray = apiResponse.data.results;
         pokemonArray.forEach(async (pokemonInfo) => {
@@ -72,7 +72,7 @@ export const Dashboard = () => {
   );
 
   useEffect(() => {
-    fetchPokemons(limit, offset);
+    fetchPokemons();
   }, [fetchPokemons]);
 
   useEffect(() => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,3 +10,5 @@ export const POKEMON_TYPES = {
 
 export const SAMPLE_POKEMON_URL =
   "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png";
+
+export const SLIDER_RANGE_ARRAY = [...new Array(100)];

--- a/src/utils/themes/colors.js
+++ b/src/utils/themes/colors.js
@@ -17,4 +17,10 @@ export const colors = {
   ghost: "#624B82",
   normal: "#557c7d",
   other: "#705848", // for other pokemon types as per api response
+  // background linear-gradient colors
+  secondaryLime: "#cafebf",
+  primaryLime: "#d7e9be",
+  paperColor: "#E1D8BD",
+  primaryPink: "#f1c4bd",
+  secondaryPink: " #fdb1bd",
 };

--- a/src/utils/themes/colors.js
+++ b/src/utils/themes/colors.js
@@ -5,6 +5,7 @@ export const colors = {
   primaryRed: "#f19686",
   secondaryRed: "#d14d36",
   primaryGray: "#808080",
+  boxShadow: "#888888",
   secondaryGray: "#393E46",
   // colors based on pokemon types
   electric: "#ebb813",


### PR DESCRIPTION
---

## Description 

 **Following are the changes this PR will make:-**

- Once the list of Pokemon's rendered within the Grid of Cards on the dashboard
- A user can hover on the same in order to check out the **Statistics** of that Pokemon
- The Stats include the level of entities such as _**Attack**_, _**Defense**_, _**HP**_, etc.

- Also some stylings and background color changes

---